### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Follow these steps to deploy your app:
 1. View the root credentials for logging in:
 
     ```shell
-    cf curl "/v3/service_instances/<credentials-id>/credentials"
+    cf curl "/v3/service_instances/$(terraform output -raw credentials_id)/credentials"
     ```
 
     Make note of the `ROOT_USER_NAME` and `ROOT_USER_PASS` credentials

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-TTS Drupal Template
-===================
+# TTS Drupal Template
 
 This repository aims to simplify the process of getting a `drupal/cms` app running in cloud.gov
 
@@ -16,7 +15,7 @@ PRs and ideas for improvement VERY much welcome.
 1. At that command line, run `./init.sh`
 1. Use terraform to deploy your app
 
-### Terraform deploy
+### Deploy to Cloud.gov
 
 Follow these steps (starting from within your app directory) to deploy your app
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Follow these steps to deploy your app:
 
 #### Log in to your Drupal site
 
-1. Run `terraform output` and copy the value of `credentials_id`
 1. View the root credentials for logging in:
 
     ```shell
@@ -47,7 +46,12 @@ Follow these steps to deploy your app:
 
     Make note of the `ROOT_USER_NAME` and `ROOT_USER_PASS` credentials
 
-1. From `terraform output`, visit the URL in `route`
+1. From `terraform output`, visit the URL in `route`:
+
+    ```shell
+    terraform output -raw route
+    ```
+
 1. Click the "Log in" button on the page
 1. Use the `ROOT_USER_NAME` and `ROOT_USER_PASS` values from the root user credentials to log in
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,49 @@ This repository aims to simplify the process of getting a `drupal/cms` app runni
 
 PRs and ideas for improvement VERY much welcome.
 
-## Usage
+## Bootstrap application and run locally
 
 1. Clone this repository
 1. Run `./bootstrap.sh PATH_TO_NEW_DIR`
 1. `bootstrap.sh` will finish by presenting you in a `ddev ssh` console
 1. At that command line, run `./init.sh`
-1. Use terraform to deploy your app
 
 ### Deploy to Cloud.gov
 
-Follow these steps (starting from within your app directory) to deploy your app
+Follow these steps to deploy your app:
+
+1. Go to the directory where you bootstrapped the app (`PATH_TO_NEW_DIR` above)
+
+    ```shell
+    cd PATH_TO_NEW_DIR
+    ```
 
 1. `cd terraform`
 1. `terraform init`
 1. `terraform validate`
-1. Create a `terraform/vars.auto.tfvars` file to define the required variables
+1. Create a `terraform/terraform.tfvars` file to define the required variables:
+
+    - `cf_org_name` - Organization name on Cloud.gov where Drupal should be deployed
+    - `cf_space_name` - Space name on Cloud.gov in `cf_org_name` where Drupal should be deployed. **This space will be created.**
+    - `app_name` - Name of deployed Drupal application
+    - `cf_users` - List of usernames that can deploy the application within `cf_space_name`
+
 1. `terraform apply` to deploy to your new space
+
+#### Log in to your Drupal site
+
+1. Run `terraform output` and copy the value of `credentials_id`
+1. View the root credentials for logging in:
+
+    ```shell
+    cf curl "/v3/service_instances/<credentials-id>/credentials"
+    ```
+
+    Make note of the `ROOT_USER_NAME` and `ROOT_USER_PASS` credentials
+
+1. From `terraform output`, visit the URL in `route`
+1. Click the "Log in" button on the page
+1. Use the `ROOT_USER_NAME` and `ROOT_USER_PASS` values from the root user credentials to log in
 
 ## Disclaimers
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,6 +73,6 @@ echo
 echo "======================================================================"
 echo
 
-ddev config --project-type=drupal11 --docroot=web
+ddev config --project-type=drupal --docroot=web
 ddev start
 ddev ssh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,8 +54,6 @@ echo "======================================================================"
 echo
 
 cd "$output_dir"
-sed 's/ddev launch/ddev ssh/' launch-drupal-cms.sh > launch-drupal-cms-ssh.sh
-chmod +x launch-drupal-cms-ssh.sh
 chmod +x init.sh
 
 echo
@@ -75,4 +73,6 @@ echo
 echo "======================================================================"
 echo
 
-exec ./launch-drupal-cms-ssh.sh
+ddev config --project-type=drupal11 --docroot=web
+ddev start
+ddev ssh

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -117,5 +117,6 @@ spatial-data/*.txt
 **/.terraform/*
 secrets.*.tfvars
 terraform.tfstate*
+.terraform
 
 .ddev/

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -115,8 +115,7 @@ spatial-data/*.txt
 # Terraform files
 .terraform.lock.hcl
 **/.terraform/*
-secrets.*.tfvars
+*.tfvars
 terraform.tfstate*
-.terraform
 
 .ddev/

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -1,6 +1,6 @@
 # create a cloud.gov space to host the app and services
 module "space" {
-  source = "github.com/gsa-tts/terraform-cloudgov//cg_space?ref=v2.2.0"
+  source = "github.com/gsa-tts/terraform-cloudgov//cg_space?ref=v2.4.1"
 
   cf_org_name          = var.cf_org_name
   cf_space_name        = var.cf_space_name
@@ -11,7 +11,7 @@ module "space" {
 
 # provision a database, s3 bucket, and deploy the application
 module "drupal" {
-  source = "github.com/gsa-tts/terraform-cloudgov//drupal?ref=v2.2.0"
+  source = "github.com/gsa-tts/terraform-cloudgov//drupal?ref=v2.4.1"
 
   cf_org_name   = var.cf_org_name
   cf_space      = module.space.space

--- a/templates/terraform/outputs.tf
+++ b/templates/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "credentials_id" {
+  value = module.drupal.credentials_id
+}
+
+output "route" {
+  value = module.drupal.endpoint
+}

--- a/templates/terraform/variables.tf
+++ b/templates/terraform/variables.tf
@@ -1,11 +1,11 @@
 variable "cf_org_name" {
   type        = string
-  description = "cloud.gov organization name"
+  description = "Organization name on Cloud.gov where Drupal should be deployed"
 }
 
 variable "cf_space_name" {
   type        = string
-  description = "cloud.gov space name for app deployment"
+  description = "Space name on Cloud.gov in `cf_org_name` where Drupal should be deployed. **This space will be created.**"
 }
 
 variable "app_name" {
@@ -15,7 +15,7 @@ variable "app_name" {
 
 variable "cf_users" {
   type        = set(string)
-  description = "Set of cloud.gov usernames that can deploy the application"
+  description = "Set of Cloud.gov usernames that can deploy the application"
 }
 
 variable "allow_ssh" {


### PR DESCRIPTION
This PR includes various fixes:

- Replace references to `launch-drupal-cms.sh` in `bootstrap.sh` with inline `ddev` commands. `launch-drupal-cms.sh` was deprecated and removed from Drupal: https://www.drupal.org/node/3513530
- Bump version of Terraform modules
- Add `.terraform` directory to `.gitignore` template